### PR TITLE
Move from numpy functions to Python list and friends

### DIFF
--- a/pyDmdReader/_api.py
+++ b/pyDmdReader/_api.py
@@ -186,27 +186,26 @@ def get_samples_with_ts_scaled_value_seconds(
 
 @_check_loaded
 def get_samples_and_ts_scaled_value_seconds(
-    channel_handle: c_void_p, first_sample: int, max_samples: int
+    channel_handle: c_void_p, first_sample: int, max_samples: int,
+    sample_values: "Array", timestamp_values: "Array"
 ) -> Tuple[int, int, "Array", "Array"]:
     """
     DMD Reader API Get samples and timestamps
     Two separate arrays
     """
-    samples = (c_double * max_samples)()
-    timestamps = (c_double * max_samples)()
     num_valid_samples = c_uint64(0)
     next_sample = c_uint64(0)
     error_code = _DMDReader_GetSamplesAndTS_ScaledValue_Seconds(
         channel_handle,
         c_uint64(first_sample),
         c_uint64(max_samples),
-        byref(samples),
-        byref(timestamps),
+        byref(sample_values),
+        byref(timestamp_values),
         byref(num_valid_samples),
         byref(next_sample)
     )
     _check_error(error_code)
-    return num_valid_samples.value, next_sample.value, samples, timestamps
+    return num_valid_samples.value, next_sample.value, sample_values, timestamp_values
 
 
 @_check_loaded
@@ -231,14 +230,13 @@ def get_samples_with_ts_reduced_value_seconds(
 
 @_check_loaded
 def get_samples_and_ts_reduced_value_seconds(
-    channel_handle: c_void_p, first_reduced_sample: int, max_reduced_samples: int
+    channel_handle: c_void_p, first_reduced_sample: int, max_reduced_samples: int,
+    reduced_samples: "Array", reduced_timestamps: "Array"
 ) -> Tuple[int, int, "Array", "Array"]:
     """
     DMD Reader API Get samples only (uses _DMDReader_GetSamplesAndTS_ReducedValue_Seconds)
     Two separate arrays
     """
-    reduced_samples = (DmdSampleValueReduced * max_reduced_samples)()
-    reduced_timestamps = (c_double * max_reduced_samples)()
     num_valid_samples = c_uint64(0)
     next_sample = c_uint64(0)
     error_code = _DMDReader_GetSamplesAndTS_ReducedValue_Seconds(
@@ -276,36 +274,34 @@ def get_samples_with_ts_digital_value_seconds(
 
 @_check_loaded
 def get_samples_and_ts_digital_value_seconds(
-    channel_handle: c_void_p, first_sample: int, max_samples: int
+    channel_handle: c_void_p, first_sample: int, max_samples: int,
+    sample_values: "Array", timestamp_values: "Array"
 ) -> Tuple[int, int, "Array", "Array"]:
     """
     DMD Reader API Get samples and timestamps
     Two separate arrays
     """
-    samples = (c_int32 * max_samples)()
-    timestamps = (c_double * max_samples)()
     num_valid_samples = c_uint64(0)
     next_sample = c_uint64(0)
     error_code = _DMDReader_GetSamplesAndTS_DigitalValue_Seconds(
         channel_handle,
         c_uint64(first_sample),
         c_uint64(max_samples),
-        byref(samples),
-        byref(timestamps),
+        byref(sample_values),
+        byref(timestamp_values),
         byref(num_valid_samples),
         byref(next_sample)
     )
     _check_error(error_code)
-    return num_valid_samples.value, next_sample.value, samples, timestamps
+    return num_valid_samples.value, next_sample.value, sample_values, timestamp_values
 
 
 @_check_loaded
 def get_samples_and_ts_scalar_vector_seconds(
-    channel_handle: c_void_p, first_sample: int, max_samples: int, max_sample_dimension: int
+    channel_handle: c_void_p, first_sample: int, max_samples: int, max_sample_dimension: int,
+    sample_values: "Array", timestamp_values: "Array"
 ) -> Tuple[int, int, "Array", "Array"]:
     """DMD Reader API Get samples and timestamps"""
-    samples = (c_double * (max_samples * max_sample_dimension))()
-    timestamps = (c_double * max_samples)()
     num_valid_samples = c_uint64(0)
     next_sample = c_uint64(0)
     error_code = _DMDReader_GetSamplesAndTS_ScalarVector_Seconds(
@@ -313,23 +309,22 @@ def get_samples_and_ts_scalar_vector_seconds(
         c_uint64(first_sample),
         c_uint64(max_samples),
         c_uint32(max_sample_dimension),
-        byref(samples),
-        byref(timestamps),
+        byref(sample_values),
+        byref(timestamp_values),
         None,
         byref(num_valid_samples),
         byref(next_sample)
     )
     _check_error(error_code)
-    return num_valid_samples.value, next_sample.value, samples, timestamps
+    return num_valid_samples.value, next_sample.value, sample_values, timestamp_values
 
 
 @_check_loaded
 def get_samples_and_ts_complex_vector_seconds(
-    channel_handle: c_void_p, first_sample: int, max_samples: int, max_sample_dimension: int
+    channel_handle: c_void_p, first_sample: int, max_samples: int, max_sample_dimension: int,
+    sample_values: "Array", timestamp_values: "Array"
 ) -> Tuple[int, int, "Array", "Array"]:
     """DMD Reader API Get samples and timestamps"""
-    samples = (DmdSampleValueComplex * (max_samples * max_sample_dimension))()
-    timestamps = (c_double * max_samples)()
     num_valid_samples = c_uint64(0)
     next_sample = c_uint64(0)
     error_code = _DMDReader_GetSamplesAndTS_ComplexVector_Seconds(
@@ -337,14 +332,14 @@ def get_samples_and_ts_complex_vector_seconds(
         c_uint64(first_sample),
         c_uint64(max_samples),
         c_uint32(max_sample_dimension),
-        byref(samples),
-        byref(timestamps),
+        byref(sample_values),
+        byref(timestamp_values),
         None,
         byref(num_valid_samples),
         byref(next_sample)
     )
     _check_error(error_code)
-    return num_valid_samples.value, next_sample.value, samples, timestamps
+    return num_valid_samples.value, next_sample.value, sample_values, timestamp_values
 
 
 # READ FILE META DATA

--- a/pyDmdReader/_api.py
+++ b/pyDmdReader/_api.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Copyright DEWETRON GmbH 2021
 
 Dmd reader library - API module
@@ -188,7 +188,7 @@ def get_samples_with_ts_scaled_value_seconds(
 def get_samples_and_ts_scaled_value_seconds(
     channel_handle: c_void_p, first_sample: int, max_samples: int,
     sample_values: "Array", timestamp_values: "Array"
-) -> Tuple[int, int, "Array", "Array"]:
+) -> Tuple[int, int]:
     """
     DMD Reader API Get samples and timestamps
     Two separate arrays
@@ -205,7 +205,7 @@ def get_samples_and_ts_scaled_value_seconds(
         byref(next_sample)
     )
     _check_error(error_code)
-    return num_valid_samples.value, next_sample.value, sample_values, timestamp_values
+    return num_valid_samples.value, next_sample.value
 
 
 @_check_loaded
@@ -232,7 +232,7 @@ def get_samples_with_ts_reduced_value_seconds(
 def get_samples_and_ts_reduced_value_seconds(
     channel_handle: c_void_p, first_reduced_sample: int, max_reduced_samples: int,
     reduced_samples: "Array", reduced_timestamps: "Array"
-) -> Tuple[int, int, "Array", "Array"]:
+) -> Tuple[int, int]:
     """
     DMD Reader API Get samples only (uses _DMDReader_GetSamplesAndTS_ReducedValue_Seconds)
     Two separate arrays
@@ -249,7 +249,7 @@ def get_samples_and_ts_reduced_value_seconds(
         byref(next_sample)
     )
     _check_error(error_code)
-    return num_valid_samples.value, next_sample.value, reduced_samples, reduced_timestamps
+    return num_valid_samples.value, next_sample.value
 
 
 @_check_loaded
@@ -276,7 +276,7 @@ def get_samples_with_ts_digital_value_seconds(
 def get_samples_and_ts_digital_value_seconds(
     channel_handle: c_void_p, first_sample: int, max_samples: int,
     sample_values: "Array", timestamp_values: "Array"
-) -> Tuple[int, int, "Array", "Array"]:
+) -> Tuple[int, int]:
     """
     DMD Reader API Get samples and timestamps
     Two separate arrays
@@ -293,14 +293,14 @@ def get_samples_and_ts_digital_value_seconds(
         byref(next_sample)
     )
     _check_error(error_code)
-    return num_valid_samples.value, next_sample.value, sample_values, timestamp_values
+    return num_valid_samples.value, next_sample.value
 
 
 @_check_loaded
 def get_samples_and_ts_scalar_vector_seconds(
     channel_handle: c_void_p, first_sample: int, max_samples: int, max_sample_dimension: int,
     sample_values: "Array", timestamp_values: "Array"
-) -> Tuple[int, int, "Array", "Array"]:
+) -> Tuple[int, int]:
     """DMD Reader API Get samples and timestamps"""
     num_valid_samples = c_uint64(0)
     next_sample = c_uint64(0)
@@ -316,14 +316,14 @@ def get_samples_and_ts_scalar_vector_seconds(
         byref(next_sample)
     )
     _check_error(error_code)
-    return num_valid_samples.value, next_sample.value, sample_values, timestamp_values
+    return num_valid_samples.value, next_sample.value
 
 
 @_check_loaded
 def get_samples_and_ts_complex_vector_seconds(
     channel_handle: c_void_p, first_sample: int, max_samples: int, max_sample_dimension: int,
     sample_values: "Array", timestamp_values: "Array"
-) -> Tuple[int, int, "Array", "Array"]:
+) -> Tuple[int, int]:
     """DMD Reader API Get samples and timestamps"""
     num_valid_samples = c_uint64(0)
     next_sample = c_uint64(0)
@@ -339,7 +339,7 @@ def get_samples_and_ts_complex_vector_seconds(
         byref(next_sample)
     )
     _check_error(error_code)
-    return num_valid_samples.value, next_sample.value, sample_values, timestamp_values
+    return num_valid_samples.value, next_sample.value
 
 
 # READ FILE META DATA

--- a/pyDmdReader/_dmd_reader.py
+++ b/pyDmdReader/_dmd_reader.py
@@ -278,9 +278,7 @@ class DmdReader:
 
                 (
                     num_valid_samples,
-                    next_reduced_sample,
-                    reduced_values,
-                    reduced_timestamps
+                    next_reduced_sample
                 ) = _api.get_samples_and_ts_reduced_value_seconds(
                     ch_config.handle,
                     sweep.first_sample,
@@ -289,7 +287,7 @@ class DmdReader:
                     reduced_timestamps
                 )
                 timestamps = np.r_[timestamps, np.frombuffer(reduced_timestamps, count=num_valid_samples)]
-                data = np.r_[data, np.frombuffer(reduced_values, count=4*num_valid_samples)]
+                data = np.r_[data, np.frombuffer(reduced_samples, count=4*num_valid_samples)]
                 if max_samples is not None:
                     max_samples -= num_valid_samples
                     if max_samples <= 0:
@@ -557,7 +555,7 @@ class DmdReader:
         """Get data for given sweep of given channel"""
         timestamps_dtype = "float64"
         if ch_config.raw_sample_type == SampleType.DOUBLE:
-            num_valid_samples, next_sample, raw_values, raw_timestamps = _api.get_samples_and_ts_scaled_value_seconds(
+            num_valid_samples, next_sample = _api.get_samples_and_ts_scaled_value_seconds(
                 ch_config.handle,
                 first_sample,
                 max_samples,
@@ -566,7 +564,7 @@ class DmdReader:
             )
         elif ch_config.raw_sample_type == SampleType.SINT32:
             # Digital
-            num_valid_samples, next_sample, raw_values, raw_timestamps = _api.get_samples_and_ts_digital_value_seconds(
+            num_valid_samples, next_sample = _api.get_samples_and_ts_digital_value_seconds(
                 ch_config.handle,
                 first_sample,
                 max_samples,
@@ -574,7 +572,7 @@ class DmdReader:
                 timestamp_values
             )
         elif ch_config.raw_sample_type == SampleType.DOUBLE_VECTOR:
-            num_valid_samples, next_sample, raw_values, raw_timestamps = _api.get_samples_and_ts_scalar_vector_seconds(
+            num_valid_samples, next_sample = _api.get_samples_and_ts_scalar_vector_seconds(
                 ch_config.handle,
                 first_sample,
                 max_samples,
@@ -583,7 +581,7 @@ class DmdReader:
                 timestamp_values
             )
         elif ch_config.raw_sample_type == SampleType.COMPLEX_VECTOR:
-            num_valid_samples, next_sample, raw_values, raw_timestamps = _api.get_samples_and_ts_complex_vector_seconds(
+            num_valid_samples, next_sample = _api.get_samples_and_ts_complex_vector_seconds(
                 ch_config.handle,
                 first_sample,
                 max_samples,
@@ -594,8 +592,8 @@ class DmdReader:
         else:
             raise NotImplementedError(f"Sampletype {ch_config.raw_sample_type} not supported")
 
-        timestamps = np.frombuffer(raw_timestamps, dtype=timestamps_dtype, count=num_valid_samples)
-        data = np.frombuffer(raw_values, dtype=ch_config.dtype, count=num_valid_samples*ch_config.max_sample_dimension)
+        timestamps = np.frombuffer(timestamp_values, dtype=timestamps_dtype, count=num_valid_samples)
+        data = np.frombuffer(sample_values, dtype=ch_config.dtype, count=num_valid_samples*ch_config.max_sample_dimension)
 
         return timestamps, data, next_sample
 


### PR DESCRIPTION
This is a series of commits that address the performance issues of handling large data files. The main performance boost is gained by avoiding numpy functions that reallocate each time the array size changes and copy the values. Instead, we use Python's list (append) and friends which sometimes guarantee operations in O(1), without copying all values all the time. The commit messages should have all information needed.

This PR reduces the loading/parsing time needed for a ~400 MB file with complex only values in one channel from >120s to <1s.
